### PR TITLE
gitmodules: Use https:// git URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/distro"]
 	path = lib/distro
-	url = git@github.com:python-distro/distro.git
+	url = https://github.com/python-distro/distro.git


### PR DESCRIPTION
Using an HTTPS URL is a bit more accessible as it doesn't require setting up an SSH key.