### PR TITLE
Fix import of distro moule

### DIFF
--- a/ifplatform.py
+++ b/ifplatform.py
@@ -13,7 +13,7 @@ from dotbot.plugins import Clean, Create, Link, Shell
 def _inject_distro():
     # Find distro in submodule
     root_dir = os.path.dirname(os.path.realpath(__file__))
-    path = os.path.join(root_dir, 'lib/distro')
+    path = os.path.join(root_dir, 'lib/distro/src/distro')
     # Update path
     sys.path.insert(0, path)
 


### PR DESCRIPTION
When using the latest version of this plugin on macOS, with a test directive in the dotbot installation configuration like

```yaml
- ifmacos:
    - shell:
        - echo "is mac!"
```

Running the `./install` in my dotfiles repo gives:

```console
[...]
Traceback (most recent call last):
  File "/Users/dotman/dotfiles/.local/repos/dotbot/bin/dotbot", line 45, in <module>
    main()
  File "/Users/dotman/dotfiles/.local/repos/dotbot/bin/dotbot", line 42, in main
    dotbot.cli.main()
  File "/Users/dotman/dotfiles/.local/repos/dotbot/dotbot/cli.py", line 133, in main
    plugins.extend(module.load(abspath))
                   ^^^^^^^^^^^^^^^^^^^^
  File "/Users/dotman/dotfiles/.local/repos/dotbot/dotbot/util/module.py", line 13, in load
    loaded_module = load_module(module_name, path)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dotman/dotfiles/.local/repos/dotbot/dotbot/util/module.py", line 32, in load_module
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/dotman/dotfiles/.local/repos/dotbot-plugins/ifplatform/ifplatform.py", line 23, in <module>
    import distro
ModuleNotFoundError: No module named 'distro'
```

I set a pdb breakpoint right before the import at 
https://github.com/ssbanerje/dotbot-ifplatform/blob/e35b5c0d7149d97ccecc8676a07895f35add725c/ifplatform.py#L22

and inspect `sys.path` and can see that it indeed contains the added entry `ifplatform/lib/distro`

```
['/Users/dotman/dotfiles/.local/repos/dotbot-plugins/ifplatform/lib/distro', '/Users/dotman/dotfiles/.local/repos/dotbot', '/Users/dotman/dotfiles/.local/repos/dotbot/lib/pyyaml/lib3', '/Users/dotman/dotfiles/.local/repos/dotbot/bin', '/usr/local/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python311.zip', '/usr/local/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11', '/usr/local/Cellar/python@3.11/3.11.3/Frameworks/Python.framework/Versions/3.11/lib/python3.11/lib-dynload', '/usr/local/lib/python3.11/site-packages']
```


I discovered though, that instead of adding `lib/distro` to `sys.path` adding `lib/distro/src/distro` did work!

With this change, the install script runs as expected

```console
$ ./install
[...]
is mac!
```