### PR TITLE
Use https for git submodule for CodeSpaces to work

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/distro"]
 	path = lib/distro
-	url = git@github.com:python-distro/distro.git
+	url = https://github.com/python-distro/distro.git


### PR DESCRIPTION
Change the protocol from SSH to HTTPS for the distro submodule. When starting a GitHub Codespaces set up with a dotfiles repo using dotbot with this plugin, it fails due to SSH auth issues etc.

Since the distro module is unrelated to this dotbot plugin, as in they are not developed together, it makes sense to use HTTPS instead of SSH anyways.

This small patch fixes it and I've confimred that using this pluging in a dotfiles repo on Codespaces does work with the patch applied.