### PR TITLE
Fix: directives executing multiple times when using multiple ifplatform blocks & Correct detection of Arch derivatives

### DIFF
--- a/ifplatform.py
+++ b/ifplatform.py
@@ -73,9 +73,13 @@ class IfPlatform(dotbot.Plugin):
                 plugin_paths.append(path)
         for path in plugin_paths:
             abspath = os.path.abspath(path)
-            plugins.extend(module.load(abspath))
+            for plugin in module.load(abspath):
+                if plugin not in plugins:
+                    plugins.append(plugin)
         if not self._context.options().disable_built_in_plugins:
-            plugins.extend([Clean, Create, Link, Shell])
+            for builtin in [Clean, Create, Link, Shell]:
+                if builtin not in plugins:
+                    plugins.append(builtin)
         return plugins
 
     def can_handle(self, directive):

--- a/ifplatform.py
+++ b/ifplatform.py
@@ -93,9 +93,12 @@ class IfPlatform(dotbot.Plugin):
         if did == 'darwin':
             did = 'macos'
 
-        if (directive == 'ifanylinux' and did in self._linux) or \
-                (directive == 'ifanybsd' and did in self._bsd) or \
-                (directive == 'if'+did):
+        # Include ID_LIKE entries so derivatives (e.g. CachyOS -> arch) match
+        all_ids = [did] + distro.like().split()
+
+        if (directive == 'ifanylinux' and any(d in self._linux for d in all_ids)) or \
+                (directive == 'ifanybsd' and any(d in self._bsd for d in all_ids)) or \
+                any(directive == 'if'+d for d in all_ids):
             self._log.debug('Matched platform %s' % did)
             return self._run_internal(data)
         else:

--- a/ifplatform.py
+++ b/ifplatform.py
@@ -66,7 +66,7 @@ class IfPlatform(dotbot.Plugin):
         self._linux = [d for d in self._distros if (d not in self._bsd) and (d != 'macos')]
 
     def _load_plugins(self):
-        plugin_paths = self._context.options().plugins
+        plugin_paths = list(self._context.options().plugins)
         plugins = []
         for dir in self._context.options().plugin_dirs:
             for path in glob.glob(os.path.join(dir, '*.py')):

--- a/tests/test_ifplatform.py
+++ b/tests/test_ifplatform.py
@@ -1,0 +1,131 @@
+import sys
+import os
+import logging
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+# dotbot isn't installed, so mock it before ifplatform is imported
+class _MockPlugin:
+    def __init__(self, context):
+        self._context = context
+        self._log = logging.getLogger('test.ifplatform')
+
+
+_mock_dotbot = MagicMock()
+_mock_dotbot.Plugin = _MockPlugin
+sys.modules.setdefault('dotbot', _mock_dotbot)
+sys.modules.setdefault('dotbot.dispatcher', MagicMock())
+sys.modules.setdefault('dotbot.util', MagicMock())
+sys.modules.setdefault('dotbot.util.module', MagicMock())
+sys.modules.setdefault('dotbot.plugins', MagicMock())
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ifplatform import IfPlatform
+import distro
+
+
+def _make_plugin():
+    context = MagicMock()
+    context.options.return_value.plugins = []
+    context.options.return_value.plugin_dirs = []
+    context.options.return_value.disable_built_in_plugins = True
+    return IfPlatform(context)
+
+
+class TestDirectMatch(unittest.TestCase):
+    """Native distro IDs match their own directive."""
+
+    @patch('distro.id', return_value='arch')
+    @patch('distro.like', return_value='')
+    def test_arch_matches_ifarch(self, _like, _id):
+        plugin = _make_plugin()
+        with patch.object(plugin, '_run_internal', return_value=True) as run:
+            plugin.handle('ifarch', [])
+            run.assert_called_once()
+
+    @patch('distro.id', return_value='ubuntu')
+    @patch('distro.like', return_value='debian')
+    def test_ubuntu_matches_ifubuntu(self, _like, _id):
+        plugin = _make_plugin()
+        with patch.object(plugin, '_run_internal', return_value=True) as run:
+            plugin.handle('ifubuntu', [])
+            run.assert_called_once()
+
+    @patch('distro.id', return_value='darwin')
+    @patch('distro.like', return_value='')
+    def test_darwin_maps_to_ifmacos(self, _like, _id):
+        plugin = _make_plugin()
+        with patch.object(plugin, '_run_internal', return_value=True) as run:
+            plugin.handle('ifmacos', [])
+            run.assert_called_once()
+
+
+class TestCachyOS(unittest.TestCase):
+    """CachyOS (ID=cachyos, ID_LIKE=arch) should match arch directives."""
+
+    @patch('distro.id', return_value='cachyos')
+    @patch('distro.like', return_value='arch')
+    def test_ifarch_matches(self, _like, _id):
+        plugin = _make_plugin()
+        with patch.object(plugin, '_run_internal', return_value=True) as run:
+            plugin.handle('ifarch', [])
+            run.assert_called_once()
+
+    @patch('distro.id', return_value='cachyos')
+    @patch('distro.like', return_value='arch')
+    def test_ifanylinux_matches(self, _like, _id):
+        plugin = _make_plugin()
+        with patch.object(plugin, '_run_internal', return_value=True) as run:
+            plugin.handle('ifanylinux', [])
+            run.assert_called_once()
+
+    @patch('distro.id', return_value='cachyos')
+    @patch('distro.like', return_value='arch')
+    def test_ifubuntu_does_not_match(self, _like, _id):
+        plugin = _make_plugin()
+        with patch.object(plugin, '_run_internal', return_value=True) as run:
+            result = plugin.handle('ifubuntu', [])
+            run.assert_not_called()
+            self.assertTrue(result)
+
+    @patch('distro.id', return_value='cachyos')
+    @patch('distro.like', return_value='arch')
+    def test_ifmacos_does_not_match(self, _like, _id):
+        plugin = _make_plugin()
+        with patch.object(plugin, '_run_internal', return_value=True) as run:
+            result = plugin.handle('ifmacos', [])
+            run.assert_not_called()
+            self.assertTrue(result)
+
+
+class TestIdLikeGeneral(unittest.TestCase):
+    """ID_LIKE with multiple entries and other derivative distros."""
+
+    @patch('distro.id', return_value='linuxmint')
+    @patch('distro.like', return_value='ubuntu debian')
+    def test_multi_value_id_like_matches_first(self, _like, _id):
+        plugin = _make_plugin()
+        with patch.object(plugin, '_run_internal', return_value=True) as run:
+            plugin.handle('ifubuntu', [])
+            run.assert_called_once()
+
+    @patch('distro.id', return_value='linuxmint')
+    @patch('distro.like', return_value='ubuntu debian')
+    def test_multi_value_id_like_matches_second(self, _like, _id):
+        plugin = _make_plugin()
+        with patch.object(plugin, '_run_internal', return_value=True) as run:
+            plugin.handle('ifdebian', [])
+            run.assert_called_once()
+
+    @patch('distro.id', return_value='linuxmint')
+    @patch('distro.like', return_value='ubuntu debian')
+    def test_ifanylinux_matches_via_id_like(self, _like, _id):
+        plugin = _make_plugin()
+        with patch.object(plugin, '_run_internal', return_value=True) as run:
+            plugin.handle('ifanylinux', [])
+            run.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hi there, thanks for the plugin! 

I have recently adopted my dotfiles to also work on linux and for this I have added this plugin. I needed to put `ifmacos` blocks into multiple places in my config and I saw that the later commands were executed multiple times.  

This PR fixes the double-execution bug that was already reported in https://github.com/ssbanerje/dotbot-ifplatform/pull/4#issuecomment-1532112176 where shell commands (and other directives) would run multiple times when a config contained more than one `ifplatform` block.

## Root cause

Two bugs in _load_plugins:

1. `plugin_paths = self._context.options().plugins` holds a reference to the shared options list, not a copy. Each call to `_load_plugins` appends plugin paths to the original list, so subsequent `ifplatform` blocks accumulate more and more plugin paths and load plugins multiple times.
2. `module.load()` scans `dir()` of the loaded module to find Plugin subclasses. Because ifplatform.py imports Clean, Create, Link, Shell at the top level, these are discovered and added to the plugin list. They are then also added explicitly at the end of `_load_plugins`. The inner Dispatcher ends up with two instances of each built-in plugin, causing every directive to execute twice.

## Fix

- Copy the options list with `list()` before mutating it
- Deduplicate plugins collected from `module.load()` and the explicit built-in additions before returning

Tested on macOS (multiple ifmacos blocks) and Arch Linux.

---

I also ran into the problem that my CashyOS was not properly detected as Arch. I have worked with Claude Code to add proper detection of the Arch derivatives and added tests.

If you want me to split this up into seperate PRs, let me know.